### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,11 @@ look like this
 
    [options.packages.find]
    where=src
+   
+   # Other options that were dicts in `setup.py` become their own subsections, e.g.:
+   [options.entry_points]
+   console_scripts =
+      <key> = <value>
 
 This file is formated according to `this
 <https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files>`_


### PR DESCRIPTION
Add general info about dicts in setup.py mapping to INI subsections

Let me know if you think this is too confusing for a simple guide.

Reference (example): https://github.com/octodns/octodns/blob/4b44ab14b1f0a52f1051c67656d6e3dd6f0ba903/setup.cfg#L34